### PR TITLE
Improve Typst list indentation

### DIFF
--- a/lua/glacier/ftbindings/typst.lua
+++ b/lua/glacier/ftbindings/typst.lua
@@ -1,104 +1,205 @@
+local api = vim.api
+
 local M = {}
 
-local function get_indent(line)
-  -- Get the leading whitespace of the line
-  local indent = line:match("^(%s*)")
-  -- Return empty string if there's no indent or just one space
-  if #indent <= 1 then
-    return ""
+local function get_shiftwidth()
+  local sw = vim.bo.shiftwidth
+  if not sw or sw == 0 then
+    sw = vim.bo.tabstop
   end
-  return indent
+  if not sw or sw == 0 then
+    sw = vim.o.shiftwidth
+  end
+  if not sw or sw == 0 then
+    sw = 2
+  end
+  return sw
 end
 
-local function get_bullet_type(line)
-  -- Return the bullet type (- or +) if present, nil otherwise
-  local bullet = line:match("^%s*([%-+])")
-  return bullet
+local function indent_for_level(level, sw)
+  if level <= 0 then
+    return ''
+  end
+  return string.rep(' ', level * sw)
 end
 
-local function starts_with_bullet(line)
-  -- Trim leading whitespace and check if line starts with - or +
-  return line:match("^%s*[%-+]")
+local function parse_line(line)
+  local indent = line:match('^(%s*)') or ''
+  local indent_width = vim.fn.strdisplaywidth(indent)
+  local bullet = line:match('^%s*([%-+])')
+
+  local info = {
+    indent = indent,
+    indent_width = indent_width,
+    bullet = bullet,
+    is_list_item = bullet ~= nil,
+    is_empty_bullet = false,
+    level = 0,
+    normalized_indent = indent,
+    shiftwidth = nil,
+    after_bullet = nil,
+  }
+
+  if info.is_list_item then
+    local sw = get_shiftwidth()
+    info.shiftwidth = sw
+    if indent_width >= sw then
+      info.level = math.floor(indent_width / sw)
+    else
+      info.level = 0
+    end
+    info.normalized_indent = indent_for_level(info.level, sw)
+    info.is_empty_bullet = line:match('^%s*[%-+]%s*$') ~= nil
+    local after = line:match('^%s*[%-+](%s.*)')
+    if not after then
+      after = line:match('^%s*[%-+](.*)') or ''
+    end
+    info.after_bullet = after
+  end
+
+  return info
 end
 
-local function is_empty_bullet(line)
-  -- Check if line is just a bullet point with optional whitespace
-  -- Must have a bullet point (- or +) to match
-  return line:match("^%s*[%-+]%s*$") ~= nil and starts_with_bullet(line)
+local function normalized_bullet_line(info)
+  local prefix = (info.normalized_indent or '') .. info.bullet
+  local after = info.after_bullet or ''
+  if after == '' then
+    return prefix .. ' '
+  end
+  if after:sub(1, 1) ~= ' ' then
+    after = ' ' .. after
+  end
+  return prefix .. after
+end
+
+local function ensure_normalized_current_line(line, info)
+  if not info.is_list_item then
+    return line, info
+  end
+  local normalized = normalized_bullet_line(info)
+  if normalized ~= line then
+    api.nvim_set_current_line(normalized)
+    info = parse_line(normalized)
+    return normalized, info
+  end
+  return line, info
+end
+
+local function ensure_normalized_line_at(row, line, info)
+  if not info.is_list_item then
+    return line, info
+  end
+  local normalized = normalized_bullet_line(info)
+  if normalized ~= line then
+    api.nvim_buf_set_lines(0, row - 1, row, false, { normalized })
+    info = parse_line(normalized)
+    return normalized, info
+  end
+  return line, info
+end
+
+local function handle_insert_enter()
+  local line = api.nvim_get_current_line()
+  local info = parse_line(line)
+  if not info.is_list_item then
+    return '<CR>'
+  end
+
+  line, info = ensure_normalized_current_line(line, info)
+  if info.is_empty_bullet then
+    return '<C-u><CR>'
+  end
+
+  return '<CR>' .. (info.normalized_indent or '') .. info.bullet .. ' '
+end
+
+local function handle_normal_o()
+  local line = api.nvim_get_current_line()
+  local info = parse_line(line)
+  if not info.is_list_item then
+    return 'o'
+  end
+
+  line, info = ensure_normalized_current_line(line, info)
+  return 'o' .. (info.normalized_indent or '') .. info.bullet .. ' '
+end
+
+local function handle_normal_O()
+  local cursor = api.nvim_win_get_cursor(0)
+  local row = cursor[1]
+  if row <= 1 then
+    return 'O'
+  end
+
+  local prev_line = api.nvim_buf_get_lines(0, row - 2, row - 1, false)[1]
+  if not prev_line then
+    return 'O'
+  end
+
+  local info = parse_line(prev_line)
+  if not info.is_list_item then
+    return 'O'
+  end
+
+  prev_line, info = ensure_normalized_line_at(row - 1, prev_line, info)
+  return 'O' .. (info.normalized_indent or '') .. info.bullet .. ' '
+end
+
+local function termcode(keys)
+  return api.nvim_replace_termcodes(keys, true, true, true)
+end
+
+local function handle_insert_tab()
+  local line = api.nvim_get_current_line()
+  local info = parse_line(line)
+  if not info.is_list_item or not info.is_empty_bullet then
+    return termcode('<Tab>')
+  end
+
+  line, info = ensure_normalized_current_line(line, info)
+  local new_level = (info.level or 0) + 1
+  local sw = info.shiftwidth or get_shiftwidth()
+  local new_indent = indent_for_level(new_level, sw)
+  local new_line = new_indent .. info.bullet .. ' '
+  api.nvim_set_current_line(new_line)
+  local row = api.nvim_win_get_cursor(0)[1]
+  api.nvim_win_set_cursor(0, { row, #new_line })
+  return ''
 end
 
 function M.setup()
-  vim.api.nvim_create_autocmd('FileType', {
+  api.nvim_create_autocmd('FileType', {
     pattern = 'typst',
     callback = function()
-      vim.keymap.set('v', '<C-b>', 'x<esc>i**<esc>P', { 
-        noremap = true, 
+      vim.keymap.set('v', '<C-b>', 'x<esc>i**<esc>P', {
+        noremap = true,
         silent = true,
         buffer = true,
-        desc = "Add asterisks around word"
+        desc = 'Add asterisks around word',
       })
 
-      -- Handle Enter in insert mode
-      vim.keymap.set('i', '<CR>', function()
-        local line = vim.api.nvim_get_current_line()
-        if is_empty_bullet(line) then
-          -- Clear the current line and move to next line
-          return '<C-u><CR>'
-        elseif starts_with_bullet(line) then
-          local indent = get_indent(line)
-          local bullet = get_bullet_type(line) or '-'
-          return '<CR>' .. indent .. bullet .. ' '
-        end
-        return '<CR>'
-      end, {
+      vim.keymap.set('i', '<CR>', handle_insert_enter, {
         buffer = true,
         expr = true,
-        desc = "Smart Enter for lists"
+        desc = 'Typst: continue list on newline',
       })
 
-      -- Handle o in normal mode
-      vim.keymap.set('n', 'o', function()
-        local line = vim.api.nvim_get_current_line()
-        if starts_with_bullet(line) then
-          local indent = get_indent(line)
-          local bullet = get_bullet_type(line) or '-'
-          return 'o' .. indent .. bullet .. ' '
-        end
-        return 'o'
-      end, {
+      vim.keymap.set('n', 'o', handle_normal_o, {
         buffer = true,
         expr = true,
-        desc = "Smart o for lists"
+        desc = 'Typst: continue list with o',
       })
 
-      -- Handle Tab in insert mode for bullet indentation
-      vim.keymap.set('i', '<Tab>', function()
-        local line = vim.api.nvim_get_current_line()
-        if is_empty_bullet(line) then
-          -- Add two spaces at the start of the line and keep cursor at end
-          return '<Esc>I  <End>'
-        end
-        return '<Tab>'
-      end, {
+      vim.keymap.set('i', '<Tab>', handle_insert_tab, {
         buffer = true,
         expr = true,
-        desc = "Smart Tab for bullet indentation"
+        desc = 'Typst: indent empty list item',
       })
 
-      -- Handle O in normal mode
-      vim.keymap.set('n', 'O', function()
-        local curr_line_nr = vim.api.nvim_win_get_cursor(0)[1]
-        local prev_line = vim.api.nvim_buf_get_lines(0, curr_line_nr - 2, curr_line_nr - 1, false)[1]
-        if prev_line and starts_with_bullet(prev_line) then
-          local indent = get_indent(prev_line)
-          local bullet = get_bullet_type(prev_line) or '-'
-          return 'O' .. indent .. bullet .. ' '
-        end
-        return 'O'
-      end, {
+      vim.keymap.set('n', 'O', handle_normal_O, {
         buffer = true,
         expr = true,
-        desc = "Smart O for lists"
+        desc = 'Typst: continue list with O',
       })
     end,
   })


### PR DESCRIPTION
## Summary
- normalize Typst list items so `-` and `+` bullets snap to multiples of the buffer shiftwidth
- reuse the normalized indentation for smart <CR>, `o`, and `O` mappings so continuation lines stay at the expected nesting level
- update the insert-mode <Tab> handler to promote empty list items by one level while keeping the cursor at the end of the bullet

## Testing
- nvim --headless -u NONE -c "lua require('glacier.ftbindings.typst').setup()" -c "q" *(fails: `nvim` is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca1caf3a4c832bafd760aea045cf86