### PR TITLE
Improve Typst list editing behavior

### DIFF
--- a/lua/glacier/ftbindings/typst.lua
+++ b/lua/glacier/ftbindings/typst.lua
@@ -82,7 +82,7 @@ function M.setup()
         end
 
         if parts.rest:match('%S') then
-          feed('<CR>' .. build_bullet(parts.indent, parts.bullet))
+          feed('<CR>')
           return
         end
 
@@ -136,33 +136,6 @@ function M.setup()
         desc = 'Indent Typst list item',
       })
 
-      vim.keymap.set('n', 'o', function()
-        local parts = parse_bullet(vim.api.nvim_get_current_line())
-        if parts then
-          return 'o' .. build_bullet(parts.indent, parts.bullet)
-        end
-        return 'o'
-      end, {
-        buffer = true,
-        expr = true,
-        desc = 'Smart o for lists',
-      })
-
-      vim.keymap.set('n', 'O', function()
-        local row = vim.api.nvim_win_get_cursor(0)[1]
-        local prev = vim.api.nvim_buf_get_lines(0, row - 2, row - 1, false)[1]
-        if prev then
-          local parts = parse_bullet(prev)
-          if parts then
-            return 'O' .. build_bullet(parts.indent, parts.bullet)
-          end
-        end
-        return 'O'
-      end, {
-        buffer = true,
-        expr = true,
-        desc = 'Smart O for lists',
-      })
     end,
   })
 end

--- a/lua/glacier/ftbindings/typst.lua
+++ b/lua/glacier/ftbindings/typst.lua
@@ -1,104 +1,167 @@
 local M = {}
 
-local function get_indent(line)
-  -- Get the leading whitespace of the line
-  local indent = line:match("^(%s*)")
-  -- Return empty string if there's no indent or just one space
-  if #indent <= 1 then
-    return ""
+local bullet_pattern = '^(%s*)([%-+])%s*(.*)$'
+
+local function parse_bullet(line)
+  local indent, bullet, rest = line:match(bullet_pattern)
+  if not bullet then
+    return nil
   end
-  return indent
+
+  return {
+    indent = indent,
+    bullet = bullet,
+    rest = rest,
+  }
 end
 
-local function get_bullet_type(line)
-  -- Return the bullet type (- or +) if present, nil otherwise
-  local bullet = line:match("^%s*([%-+])")
-  return bullet
+local function build_bullet(indent, bullet, rest)
+  if rest and rest:match('%S') then
+    return indent .. bullet .. ' ' .. rest
+  end
+  return indent .. bullet .. ' '
 end
 
-local function starts_with_bullet(line)
-  -- Trim leading whitespace and check if line starts with - or +
-  return line:match("^%s*[%-+]")
+local function termcodes(str)
+  return vim.api.nvim_replace_termcodes(str, true, false, true)
 end
 
-local function is_empty_bullet(line)
-  -- Check if line is just a bullet point with optional whitespace
-  -- Must have a bullet point (- or +) to match
-  return line:match("^%s*[%-+]%s*$") ~= nil and starts_with_bullet(line)
+local function feed(keys)
+  vim.api.nvim_feedkeys(termcodes(keys), 'n', true)
+end
+
+local function get_shiftwidth()
+  local sw = vim.bo.shiftwidth
+  if sw == 0 then
+    sw = vim.bo.tabstop
+  end
+  if not sw or sw == 0 then
+    sw = 2
+  end
+  return sw
+end
+
+local function make_indent(width)
+  if width <= 0 then
+    return ''
+  end
+
+  if vim.bo.expandtab then
+    return string.rep(' ', width)
+  end
+
+  local tabstop = vim.bo.tabstop
+  if tabstop == 0 then
+    tabstop = 8
+  end
+
+  local tabs = math.floor(width / tabstop)
+  local spaces = width - (tabs * tabstop)
+  return string.rep('\t', tabs) .. string.rep(' ', spaces)
 end
 
 function M.setup()
   vim.api.nvim_create_autocmd('FileType', {
     pattern = 'typst',
     callback = function()
-      vim.keymap.set('v', '<C-b>', 'x<esc>i**<esc>P', { 
-        noremap = true, 
+      vim.keymap.set('v', '<C-b>', 'x<esc>i**<esc>P', {
+        noremap = true,
         silent = true,
         buffer = true,
-        desc = "Add asterisks around word"
+        desc = 'Add asterisks around word',
       })
 
-      -- Handle Enter in insert mode
       vim.keymap.set('i', '<CR>', function()
+        local row = vim.api.nvim_win_get_cursor(0)[1]
         local line = vim.api.nvim_get_current_line()
-        if is_empty_bullet(line) then
-          -- Clear the current line and move to next line
-          return '<C-u><CR>'
-        elseif starts_with_bullet(line) then
-          local indent = get_indent(line)
-          local bullet = get_bullet_type(line) or '-'
-          return '<CR>' .. indent .. bullet .. ' '
+        local parts = parse_bullet(line)
+
+        if not parts then
+          feed('<CR>')
+          return
         end
-        return '<CR>'
+
+        if parts.rest:match('%S') then
+          feed('<CR>' .. build_bullet(parts.indent, parts.bullet))
+          return
+        end
+
+        local current_indent = vim.fn.indent(row)
+        if current_indent <= 0 then
+          vim.api.nvim_buf_set_lines(0, row - 1, row, false, { '' })
+          vim.api.nvim_win_set_cursor(0, { row, 0 })
+          return
+        end
+
+        local new_width = current_indent - get_shiftwidth()
+        if new_width < 0 then
+          new_width = 0
+        end
+
+        local new_indent = make_indent(new_width)
+        local new_line = build_bullet(new_indent, parts.bullet)
+        vim.api.nvim_buf_set_lines(0, row - 1, row, false, { new_line })
+        vim.api.nvim_win_set_cursor(0, { row, #new_line })
       end, {
         buffer = true,
-        expr = true,
-        desc = "Smart Enter for lists"
+        desc = 'Smart Enter for Typst lists',
       })
 
-      -- Handle o in normal mode
-      vim.keymap.set('n', 'o', function()
+      vim.keymap.set('i', '<Tab>', function()
+        local row, col = unpack(vim.api.nvim_win_get_cursor(0))
         local line = vim.api.nvim_get_current_line()
-        if starts_with_bullet(line) then
-          local indent = get_indent(line)
-          local bullet = get_bullet_type(line) or '-'
-          return 'o' .. indent .. bullet .. ' '
+        local parts = parse_bullet(line)
+
+        if not parts then
+          feed('<Tab>')
+          return
+        end
+
+        local current_indent = vim.fn.indent(row)
+        local new_indent = make_indent(current_indent + get_shiftwidth())
+        local new_line = build_bullet(new_indent, parts.bullet, parts.rest)
+        vim.api.nvim_buf_set_lines(0, row - 1, row, false, { new_line })
+
+        local col_shift = #new_indent - #parts.indent
+        local new_col = col + col_shift
+        if new_col < 0 then
+          new_col = 0
+        end
+        if new_col > #new_line then
+          new_col = #new_line
+        end
+        vim.api.nvim_win_set_cursor(0, { row, new_col })
+      end, {
+        buffer = true,
+        desc = 'Indent Typst list item',
+      })
+
+      vim.keymap.set('n', 'o', function()
+        local parts = parse_bullet(vim.api.nvim_get_current_line())
+        if parts then
+          return 'o' .. build_bullet(parts.indent, parts.bullet)
         end
         return 'o'
       end, {
         buffer = true,
         expr = true,
-        desc = "Smart o for lists"
+        desc = 'Smart o for lists',
       })
 
-      -- Handle Tab in insert mode for bullet indentation
-      vim.keymap.set('i', '<Tab>', function()
-        local line = vim.api.nvim_get_current_line()
-        if is_empty_bullet(line) then
-          -- Add two spaces at the start of the line and keep cursor at end
-          return '<Esc>I  <End>'
-        end
-        return '<Tab>'
-      end, {
-        buffer = true,
-        expr = true,
-        desc = "Smart Tab for bullet indentation"
-      })
-
-      -- Handle O in normal mode
       vim.keymap.set('n', 'O', function()
-        local curr_line_nr = vim.api.nvim_win_get_cursor(0)[1]
-        local prev_line = vim.api.nvim_buf_get_lines(0, curr_line_nr - 2, curr_line_nr - 1, false)[1]
-        if prev_line and starts_with_bullet(prev_line) then
-          local indent = get_indent(prev_line)
-          local bullet = get_bullet_type(prev_line) or '-'
-          return 'O' .. indent .. bullet .. ' '
+        local row = vim.api.nvim_win_get_cursor(0)[1]
+        local prev = vim.api.nvim_buf_get_lines(0, row - 2, row - 1, false)[1]
+        if prev then
+          local parts = parse_bullet(prev)
+          if parts then
+            return 'O' .. build_bullet(parts.indent, parts.bullet)
+          end
         end
         return 'O'
       end, {
         buffer = true,
         expr = true,
-        desc = "Smart O for lists"
+        desc = 'Smart O for lists',
       })
     end,
   })


### PR DESCRIPTION
## Summary
- add helpers to parse Typst bullet lines and build consistent prefixes
- keep new bullets at their current indent while allowing <Tab> to shift right
- let <CR> on an empty item shift the bullet left or clear it when already outermost

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca2927544c832ba0da2c808290c1e4