### PR TITLE
Remove extra indent duplication in typst mappings

### DIFF
--- a/lua/glacier/ftbindings/typst.lua
+++ b/lua/glacier/ftbindings/typst.lua
@@ -1,15 +1,5 @@
 local M = {}
 
-local function get_indent(line)
-  -- Get the leading whitespace of the line
-  local indent = line:match("^(%s*)")
-  -- Return empty string if there's no indent or just one space
-  if #indent <= 1 then
-    return ""
-  end
-  return indent
-end
-
 local function get_bullet_type(line)
   -- Return the bullet type (- or +) if present, nil otherwise
   local bullet = line:match("^%s*([%-+])")
@@ -45,9 +35,8 @@ function M.setup()
           -- Clear the current line and move to next line
           return '<C-u><CR>'
         elseif starts_with_bullet(line) then
-          local indent = get_indent(line)
           local bullet = get_bullet_type(line) or '-'
-          return '<CR>' .. indent .. bullet .. ' '
+          return '<CR>' .. bullet .. ' '
         end
         return '<CR>'
       end, {
@@ -60,9 +49,8 @@ function M.setup()
       vim.keymap.set('n', 'o', function()
         local line = vim.api.nvim_get_current_line()
         if starts_with_bullet(line) then
-          local indent = get_indent(line)
           local bullet = get_bullet_type(line) or '-'
-          return 'o' .. indent .. bullet .. ' '
+          return 'o' .. bullet .. ' '
         end
         return 'o'
       end, {
@@ -90,9 +78,8 @@ function M.setup()
         local curr_line_nr = vim.api.nvim_win_get_cursor(0)[1]
         local prev_line = vim.api.nvim_buf_get_lines(0, curr_line_nr - 2, curr_line_nr - 1, false)[1]
         if prev_line and starts_with_bullet(prev_line) then
-          local indent = get_indent(prev_line)
           local bullet = get_bullet_type(prev_line) or '-'
-          return 'O' .. indent .. bullet .. ' '
+          return 'O' .. bullet .. ' '
         end
         return 'O'
       end, {


### PR DESCRIPTION
## Summary
- stop typst bullet handlers from injecting extra leading whitespace when continuing lists
- keep the existing Tab, Enter, o, and O key behaviour while avoiding duplicate indentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca2f846d38832b8c603a28e1eb2cfc